### PR TITLE
Implemented `Debug` for `custom::Validated<T>` when `T` is `Debug`

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -80,6 +80,16 @@ impl<T> std::ops::DerefMut for Validated<T> {
     }
 }
 
+impl<T> Debug for Validated<T>
+where
+    T: Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Validated").field(&self.0).finish()
+    }
+}
+
 pub struct ValidatedFut<T: FromRequest> {
     req: actix_web::HttpRequest,
     fut: <T as FromRequest>::Future,
@@ -337,6 +347,18 @@ mod test {
             Bytes::from_static(
                 b"{\"custom_message\":\"My custom message\",\"errors\":[\"name not long enough\"]}"
             )
+        );
+    }
+
+    #[test]
+    async fn debug_for_validated_should_work() {
+        let v = Validated(ExamplePayload {
+            name: "abcde".to_string(),
+        });
+
+        assert_eq!(
+            "Validated(ExamplePayload { name: \"abcde\" })",
+            format!("{v:?}")
         );
     }
 }


### PR DESCRIPTION
I forgot this in https://github.com/ranger-ross/actix-web-validation/pull/20