### PR TITLE
Updated to garde 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ rust-version = "1.72"
 actix-web = "4"
 thiserror = "2"
 validator = { version = "0.19", optional = true }
-garde = { version = "0.20", optional = true }
+garde = { version = "0.21", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"
 validator = { version = "0.19", features = ["derive"] }
-garde = { version = "0.20", features = ["derive"] }
+garde = { version = "0.21", features = ["derive"] }
 derive_more = { version = "1", features = ["display"] }
 
 [features]


### PR DESCRIPTION
https://github.com/jprochazk/garde/releases/tag/v0.21.0