### PR TITLE
chore: Update validation dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ rust-version = "1.72"
 [dependencies]
 actix-web = "4"
 thiserror = "2"
-validator = { version = "0.19", optional = true }
-garde = { version = "0.21", optional = true }
+validator = { version = "0.20", optional = true }
+garde = { version = "0.22", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"
-validator = { version = "0.19", features = ["derive"] }
-garde = { version = "0.21", features = ["derive"] }
+validator = { version = "0.20", features = ["derive"] }
+garde = { version = "0.22", features = ["derive"] }
 derive_more = { version = "1", features = ["display"] }
 
 [features]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -173,12 +173,12 @@ fn _flatten_errors(
     errors
         .errors()
         .iter()
-        .flat_map(|(&field, err)| {
+        .flat_map(|(field, err)| {
             let indent = indent.unwrap_or(0);
             let actual_path = path
                 .as_ref()
-                .map(|path| [path.as_str(), field].join("."))
-                .unwrap_or_else(|| field.to_owned());
+                .map(|path| [path.as_str(), &field].join("."))
+                .unwrap_or_else(|| field.to_string());
             match err {
                 ValidationErrorsKind::Field(field_errors) => field_errors
                     .iter()


### PR DESCRIPTION
Makes this library work correctly with validator `0.20` & probably garde...

cc @Kubaryt